### PR TITLE
Fix typo for priorityClassName

### DIFF
--- a/charts/warden/templates/deployment.yaml
+++ b/charts/warden/templates/deployment.yaml
@@ -28,9 +28,9 @@ spec:
       serviceAccountName: {{ include "warden.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      { { - if or .Values.imageRenderer.priorityClassName .Values.global.priorityClassName } }
-      priorityClassName: { { coalesce .Values.imageRenderer.priorityClassName .Values.global.priorityClassName } }
-      { { - end } }
+      {{- if or .Values.imageRenderer.priorityClassName .Values.global.priorityClassName }}
+      priorityClassName: {{ coalesce .Values.imageRenderer.priorityClassName .Values.global.priorityClassName }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -59,3 +59,7 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+global: {}
+
+imageRenderer: {}


### PR DESCRIPTION
## Description

- Fix `using repository 'https://github.com/kyma-project/warden/releases/download/v0.0.5/warden-0.0.5.tgz' : failed helm client render: Failed to render HELM template for component 'warden': YAML parse error on warden/templates/deployment.yaml: error converting YAML to JSON: yaml: line 26: could not find expected ':'`.