### PR TITLE
Use buffered channel for timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ install-admission-k3d: build-admission
 ## Install
 
 install:
-	 helm upgrade --install --namespace kyma-system --wait warden ./charts/warden/
+	 helm upgrade --install --wait warden ./charts/warden/
 
 uninstall:
 	helm uninstall warden --wait

--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ install-admission-k3d: build-admission
 ## Install
 
 install:
-	 helm upgrade --install --wait warden ./charts/warden/
+	 helm upgrade --install --namespace kyma-system --wait warden ./charts/warden/
 
 uninstall:
 	helm uninstall warden --wait

--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -12,10 +12,10 @@ fullnameOverride: ""
 #Service configuration
 global:
   operator:
-    image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-45
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-53
 
   admission:
-    image: europe-docker.pkg.dev/kyma-project/dev/warden/admission:PR-45
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/admission:PR-53
     annotations:
       sidecar.istio.io/inject: "false"
   config:

--- a/internal/admission/decorators.go
+++ b/internal/admission/decorators.go
@@ -44,8 +44,9 @@ func HandleWithTimeout(timeout time.Duration, handler Handler) Handler {
 		defer cancel()
 
 		var resp admission.Response
-		done := make(chan bool)
+		done := make(chan bool, 1)
 		go func() {
+			defer close(done)
 			resp = handler(ctxTimeout, req)
 			done <- true
 		}()

--- a/internal/admission/defaulting_test.go
+++ b/internal/admission/defaulting_test.go
@@ -3,13 +3,13 @@ package admission
 import (
 	"context"
 	"encoding/json"
+	"github.com/kyma-project/warden/internal/test_helpers"
 	"github.com/kyma-project/warden/internal/validate"
 	"github.com/kyma-project/warden/internal/validate/mocks"
 	"github.com/kyma-project/warden/pkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -24,7 +24,7 @@ import (
 
 func TestTimeout(t *testing.T) {
 	//GIVEN
-	logger := zap.NewNop()
+	logger := test_helpers.NewTestZapLogger(t)
 	scheme := runtime.NewScheme()
 	require.NoError(t, corev1.AddToScheme(scheme))
 	decoder, err := admission.NewDecoder(scheme)
@@ -94,6 +94,7 @@ func TestTimeout(t *testing.T) {
 			time.Sleep(timeout * 2)
 		})
 		srv := httptest.NewServer(h)
+		defer srv.CloseClientConnections()
 		defer srv.Close()
 
 		validateImage := validate.NewImageValidator(&validate.ServiceConfig{NotaryConfig: validate.NotaryConfig{Url: srv.URL}}, validate.NotaryRepoFactory{})

--- a/internal/admission/defaulting_test.go
+++ b/internal/admission/defaulting_test.go
@@ -94,7 +94,6 @@ func TestTimeout(t *testing.T) {
 			time.Sleep(timeout * 2)
 		})
 		srv := httptest.NewServer(h)
-		defer srv.CloseClientConnections()
 		defer srv.Close()
 
 		validateImage := validate.NewImageValidator(&validate.ServiceConfig{NotaryConfig: validate.NotaryConfig{Url: srv.URL}}, validate.NotaryRepoFactory{})

--- a/internal/validate/image.go
+++ b/internal/validate/image.go
@@ -59,6 +59,7 @@ func NewImageValidator(sc *ServiceConfig, notaryClientFactory RepoFactory) Image
 
 func (s *notaryService) Validate(ctx context.Context, image string) error {
 	logger := helpers.LoggerFromCtx(ctx).With("image", image)
+	newCtx := helpers.LoggerToContext(ctx, logger)
 	split := strings.Split(image, tagDelim)
 
 	if len(split) != 2 {
@@ -73,12 +74,12 @@ func (s *notaryService) Validate(ctx context.Context, image string) error {
 		return nil
 	}
 
-	expectedShaBytes, err := s.loggedGetNotaryImageDigestHash(ctx, imgRepo, imgTag)
+	expectedShaBytes, err := s.loggedGetNotaryImageDigestHash(newCtx, imgRepo, imgTag)
 	if err != nil {
 		return err
 	}
 
-	shaBytes, err := s.loggedGetImageDigestHash(ctx, image)
+	shaBytes, err := s.loggedGetImageDigestHash(newCtx, image)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
- Use buffered channel to not block `go routine` from finish