### PR TITLE
Unify labels

### DIFF
--- a/charts/warden/charts/admission/templates/deployment.yaml
+++ b/charts/warden/charts/admission/templates/deployment.yaml
@@ -3,14 +3,22 @@ kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
+      app: {{ .Values.global.name }}
+      app.kubernetes.io/name: {{ .Values.global.name }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
+        app: {{ .Values.global.name }}
+        app.kubernetes.io/name: {{ .Values.global.name }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
       annotations:
         {{ toYaml .Values.global.admission.annotations | indent 8}}
     spec:

--- a/charts/warden/charts/admission/templates/deployment.yaml
+++ b/charts/warden/charts/admission/templates/deployment.yaml
@@ -5,19 +5,19 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   selector:
     matchLabels:
       app: {{ .Values.global.name }}
-      app.kubernetes.io/name: {{ .Values.global.name }}
+      app.kubernetes.io/part-of: {{ .Values.global.name }}
       app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       labels:
         app: {{ .Values.global.name }}
-        app.kubernetes.io/name: {{ .Values.global.name }}
+        app.kubernetes.io/part-of: {{ .Values.global.name }}
         app.kubernetes.io/component: {{ .Chart.Name }}
       annotations:
         {{ toYaml .Values.global.admission.annotations | indent 8}}

--- a/charts/warden/charts/admission/templates/secret.yaml
+++ b/charts/warden/charts/admission/templates/secret.yaml
@@ -6,5 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/admission/templates/secret.yaml
+++ b/charts/warden/charts/admission/templates/secret.yaml
@@ -5,4 +5,6 @@ metadata:
   name: {{ .Chart.Name }}-cert
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ .Chart.Name }}
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/admission/templates/service.yaml
+++ b/charts/warden/charts/admission/templates/service.yaml
@@ -10,4 +10,6 @@ spec:
       protocol: TCP
       targetPort: 8443
   selector:
-    app: {{ .Chart.Name }}
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/admission/templates/service.yaml
+++ b/charts/warden/charts/admission/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   ports:
@@ -15,5 +15,5 @@ spec:
       targetPort: 8443
   selector:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/admission/templates/service.yaml
+++ b/charts/warden/charts/admission/templates/service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   ports:
     - name: https-admission

--- a/charts/warden/charts/operator/templates/_helpers.tpl
+++ b/charts/warden/charts/operator/templates/_helpers.tpl
@@ -46,7 +46,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 Selector labels
 */}}
 {{- define "warden.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "warden.name" . }}
+app.kubernetes.io/part-of: {{ include "warden.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 

--- a/charts/warden/charts/operator/templates/deployment.yaml
+++ b/charts/warden/charts/operator/templates/deployment.yaml
@@ -4,16 +4,22 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
   labels:
-    role: manager
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: {{ .Chart.Name }}
+      app: {{ .Values.global.name }}
+      app.kubernetes.io/name: {{ .Values.global.name }}
+      app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       labels:
-        app: {{ .Chart.Name }}
+        app: {{ .Values.global.name }}
+        app.kubernetes.io/name: {{ .Values.global.name }}
+        app.kubernetes.io/component: {{ .Chart.Name }}
     spec:
       serviceAccountName: {{ .Chart.Name }}
       containers:

--- a/charts/warden/charts/operator/templates/deployment.yaml
+++ b/charts/warden/charts/operator/templates/deployment.yaml
@@ -5,20 +5,20 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: {{ .Values.global.name }}
-      app.kubernetes.io/name: {{ .Values.global.name }}
+      app.kubernetes.io/part-of: {{ .Values.global.name }}
       app.kubernetes.io/component: {{ .Chart.Name }}
   template:
     metadata:
       labels:
         app: {{ .Values.global.name }}
-        app.kubernetes.io/name: {{ .Values.global.name }}
+        app.kubernetes.io/part-of: {{ .Values.global.name }}
         app.kubernetes.io/component: {{ .Chart.Name }}
     spec:
       serviceAccountName: {{ .Chart.Name }}

--- a/charts/warden/charts/operator/templates/service.yaml
+++ b/charts/warden/charts/operator/templates/service.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}
 spec:
   ports:
@@ -15,5 +15,5 @@ spec:
       targetPort: https
   selector:
     app: {{ .Values.global.name }}
-    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/part-of: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/operator/templates/service.yaml
+++ b/charts/warden/charts/operator/templates/service.yaml
@@ -2,8 +2,9 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    app: {{ .Chart.Name }}
-  name: {{ .Chart.Name }}
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
   ports:
@@ -12,4 +13,6 @@ spec:
       protocol: TCP
       targetPort: https
   selector:
-    app: {{ .Chart.Name }}
+    app: {{ .Values.global.name }}
+    app.kubernetes.io/name: {{ .Values.global.name }}
+    app.kubernetes.io/component: {{ .Chart.Name }}

--- a/charts/warden/charts/operator/templates/service.yaml
+++ b/charts/warden/charts/operator/templates/service.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Values.global.name }}
     app.kubernetes.io/name: {{ .Values.global.name }}
     app.kubernetes.io/component: {{ .Chart.Name }}
-  namespace: {{ .Release.Namespace }}
 spec:
   ports:
     - name: https

--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -11,6 +11,7 @@ fullnameOverride: ""
 
 #Service configuration
 global:
+  name: warden
   operator:
     image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-59
 


### PR DESCRIPTION
Unify labels to have:
- ability to get logs from admission and operator by label: `kubectl logs -l app=warden --prefix=true`
- distinguish between operator and admission
- The version 0.0.6 is upgradable to this version

See: #42 