### PR TITLE
Bump warden images before release

### DIFF
--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 global:
   name: warden
   operator:
-    image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-82
+    image: europe-docker.pkg.dev/kyma-project/prod/warden/operator:v20230308-656f93ee
     resources:
       requests:
         cpu: 10m
@@ -22,7 +22,7 @@ global:
         memory: 160Mi
 
   admission:
-    image: europe-docker.pkg.dev/kyma-project/dev/warden/admission:PR-82
+    image: europe-docker.pkg.dev/kyma-project/prod/warden/admission:v20230308-656f93ee
     resources:
       requests:
         cpu: 10m


### PR DESCRIPTION
Use signed images as a preparation for 0.3.3 release
