### PR TITLE
Add auto-rollout of warden workloads upon helm upgrade

### DIFF
--- a/charts/warden/charts/admission/templates/deployment.yaml
+++ b/charts/warden/charts/admission/templates/deployment.yaml
@@ -20,7 +20,8 @@ spec:
         app.kubernetes.io/part-of: {{ .Values.global.name }}
         app.kubernetes.io/component: {{ .Chart.Name }}
       annotations:
-        {{ toYaml .Values.global.admission.annotations | indent 8}}
+        sidecar.istio.io/inject: "false"
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       serviceAccountName: {{ .Chart.Name }}
       containers:

--- a/charts/warden/charts/operator/templates/deployment.yaml
+++ b/charts/warden/charts/operator/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         app: {{ .Values.global.name }}
         app.kubernetes.io/part-of: {{ .Values.global.name }}
         app.kubernetes.io/component: {{ .Chart.Name }}
+      annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
     spec:
       serviceAccountName: {{ .Chart.Name }}
       containers:

--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -12,7 +12,7 @@ fullnameOverride: ""
 global:
   name: warden
   operator:
-    image: europe-docker.pkg.dev/kyma-project/prod/warden/operator:v20230308-656f93ee
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-94
     resources:
       requests:
         cpu: 10m
@@ -22,7 +22,7 @@ global:
         memory: 160Mi
 
   admission:
-    image: europe-docker.pkg.dev/kyma-project/prod/warden/admission:v20230308-656f93ee
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/admission:PR-94
     resources:
       requests:
         cpu: 10m
@@ -31,8 +31,6 @@ global:
         cpu: 300m
         memory: 300Mi
 
-    annotations:
-      sidecar.istio.io/inject: "false"
   config:
     dir: /workspace
     filename: config.yaml

--- a/internal/validate/image_test.go
+++ b/internal/validate/image_test.go
@@ -3,6 +3,11 @@ package validate_test
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
 	"github.com/kyma-project/warden/internal/validate"
 	"github.com/kyma-project/warden/internal/validate/mocks"
 	"github.com/kyma-project/warden/pkg"
@@ -11,10 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/theupdateframework/notary/client"
 	"golang.org/x/net/context"
-	"net/http"
-	"net/http/httptest"
-	"testing"
-	"time"
 )
 
 type image struct {
@@ -29,9 +30,9 @@ func (i image) image() string {
 
 var (
 	trustedImage = image{
-		name: "eu.gcr.io/kyma-project/function-controller",
-		tag:  "PR-16481",
-		hash: []byte{243, 155, 151, 155, 35, 94, 175, 164, 30, 8, 73, 56, 233, 106, 9, 124, 3, 46, 36, 141, 41, 227, 150, 143, 207, 210, 152, 26, 190, 95, 17, 166},
+		name: "europe-docker.pkg.dev/kyma-project/prod/function-controller",
+		tag:  "v20230428-1ea34f8e",
+		hash: []byte{244, 18, 77, 237, 156, 176, 43, 214, 188, 171, 25, 208, 79, 227, 163, 71, 22, 44, 31, 78, 117, 94, 30, 156, 54, 216, 160, 253, 117, 117, 78, 190},
 	}
 	differentHashImage = image{
 		name: "nginx",

--- a/tests/operator_test.go
+++ b/tests/operator_test.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	UntrustedImageName = "nginx:latest"
-	TrustedImageName   = "eu.gcr.io/kyma-project/function-controller:PR-16481"
+	TrustedImageName   = "europe-docker.pkg.dev/kyma-project/prod/function-controller:v20230428-1ea34f8e"
 )
 
 //TODO: as unit tests:


### PR DESCRIPTION
**Description**

annotate workloads workloads to roll them with helm upgrades.

**Related issues**
https://github.com/kyma-project/warden/issues/93
