### PR TITLE
Sec scanners config latest tags

### DIFF
--- a/docker/admission/Dockerfile
+++ b/docker/admission/Dockerfile
@@ -23,6 +23,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o admission ./cmd/admission/main.go
 
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -23,6 +23,7 @@ COPY pkg/ pkg/
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
 RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o operator ./cmd/operator/main.go
 
+
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot

--- a/hack/create-module.sh
+++ b/hack/create-module.sh
@@ -8,6 +8,8 @@ HELM=${HELM?"Define HELM env"}
 MODULE_REGISTRY=${MODULE_REGISTRY?"Define MODULE_REGISTRY env"}
 
 # optional envs
+SEC_SCANNERS_CONFIG=${SEC_SCANNERS_CONFIG:-}
+
 CHANNEL="${CHANNEL:-fast}"
 
 DEFAULT_NAME=$(cat sec-scanners-config.yaml | grep module-name | sed 's/module-name: //g')
@@ -36,5 +38,6 @@ cat module-config-template.yaml |
 ## create module
 printf "Create module\n"
 ${KYMA} alpha create module --path . --output=moduletemplate.yaml \
+    --sec-scanners-config="$SEC_SCANNERS_CONFIG" \
     --module-config-file=module-config.yaml \
     --registry ${MODULE_REGISTRY} ${CREATE_MODULE_EXTRA_ARGS} --module-archive-version-overwrite

--- a/module-config-template.yaml
+++ b/module-config-template.yaml
@@ -2,7 +2,6 @@ name: {{.Name}}
 channel: {{.Channel}}
 version: {{.Version}}
 manifest: warden-manifest.yaml
-security: sec-scanners-config.yaml
 annotations:
   "operator.kyma-project.io/doc-url": "https://github.com/kyma-project/warden/blob/{{.Version}}/README.md"
 moduleRepo: https://github.com/kyma-project/warden.git

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,8 +1,8 @@
 module-name: warden
 rc-tag: v0.5.1
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/warden/operator:v20231011-fe44448b
-  - europe-docker.pkg.dev/kyma-project/prod/warden/admission:v20231011-fe44448b
+  - europe-docker.pkg.dev/kyma-project/prod/warden/operator:latest
+  - europe-docker.pkg.dev/kyma-project/prod/warden/admission:latest
 whitesource:
   language: golang-mod
   subprojects: false


### PR DESCRIPTION
**Description:**

- use the `latest` tags in sec-scanners-config
- re-trigger building jobs
- we should not use sec-scanners-config to build moduletemplate because this config is used only to scan moduletemplate on production (this does not happen in this repo). In this repo, we should only test the integration and prepare ready to build module

**Issue:**
- https://github.com/kyma-project/serverless/issues/411