### PR TITLE
Bump golang runtime 1.21.5

### DIFF
--- a/docker/admission/Dockerfile
+++ b/docker/admission/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.2 as builder
+FROM golang:1.21.5 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docker/operator/Dockerfile
+++ b/docker/operator/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21.2 as builder
+FROM golang:1.21.5 as builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump golang-runtime version to 1.21.5

