### PR TITLE
Remove secrets and configmaps from the cache

### DIFF
--- a/charts/warden/values.yaml
+++ b/charts/warden/values.yaml
@@ -20,7 +20,7 @@ global:
   wardenPriorityClassName: warden-priority
   wardenPriorityClassValue: 2000000
   operator:
-    image: europe-docker.pkg.dev/kyma-project/prod/warden/operator:v20231222-48a12c63
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/operator:PR-170
     resources:
       requests:
         cpu: 10m
@@ -30,7 +30,7 @@ global:
         memory: 160Mi
 
   admission:
-    image: europe-docker.pkg.dev/kyma-project/prod/warden/admission:v20231222-48a12c63
+    image: europe-docker.pkg.dev/kyma-project/dev/warden/admission:PR-170
     resources:
       requests:
         cpu: 10m

--- a/cmd/admission/main.go
+++ b/cmd/admission/main.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -108,6 +109,10 @@ func main() {
 		Port:               appConfig.Admission.Port,
 		MetricsBindAddress: ":9090",
 		Logger:             logrZap,
+		ClientDisableCacheFor: []ctrlclient.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 	})
 	if err != nil {
 		logger.Error("failed to start manager", err.Error())

--- a/cmd/operator/main.go
+++ b/cmd/operator/main.go
@@ -33,10 +33,12 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	zapk8s "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	//+kubebuilder:scaffold:imports
@@ -97,6 +99,10 @@ func main() {
 		LeaderElection:         appConfig.Operator.LeaderElect,
 		LeaderElectionID:       "c3790980.warden.kyma-project.io",
 		Logger:                 logrZap,
+		ClientDisableCacheFor: []ctrlclient.Object{
+			&corev1.Secret{},
+			&corev1.ConfigMap{},
+		},
 		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
 		// when the Manager ends. This requires the binary to immediately end when the
 		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**
Exclude secrets and config maps from being auto-loaded to controllers cache

Changes proposed in this pull request:

- Remove secrets and configmaps from the cache in `operator`
- Remove secrets and configmaps from the cache in `admission`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#151