### PR TITLE
Enable cache only for 1 object

### DIFF
--- a/internal/webhook/controller.go
+++ b/internal/webhook/controller.go
@@ -2,6 +2,7 @@ package webhook
 
 import (
 	"context"
+	corev1 "k8s.io/api/core/v1"
 	"os"
 	"path"
 	"time"
@@ -11,7 +12,6 @@ import (
 	"github.com/kyma-project/warden/internal/webhook/certs"
 	"github.com/pkg/errors"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- as in title
- See: https://github.com/kubernetes-sigs/controller-runtime/blob/main/designs/use-selectors-at-cache.md

**Related issue(s)**
https://github.com/kyma-project/warden/issues/151
