### PR TITLE
Test warden on k8s 1.28.6

### DIFF
--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -17,6 +17,7 @@ jobs:
             --agents 1
             --port 80:80@loadbalancer
             --port 443:443@loadbalancer
+            --image rancher/k3s:v1.28.6-k3s1
             --wait
       - name: set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/warden-verify.yaml
+++ b/.github/workflows/warden-verify.yaml
@@ -44,6 +44,7 @@ jobs:
           --agents 1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
+          --image rancher/k3s:v1.28.6-k3s1
           --wait
     - uses: actions/setup-go@v4
       with:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

 - Run integration tests on k8s v1.28

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/5057