### PR TITLE
Fix link to promotion action run

### DIFF
--- a/.github/workflows/promote-to-release-channel-with-config.yaml
+++ b/.github/workflows/promote-to-release-channel-with-config.yaml
@@ -13,7 +13,7 @@ on:
         required: true
       channel:
         description: 'Module channel'
-        default: "fast"
+        default: "regular"
         required: true
 
 env:
@@ -147,4 +147,4 @@ jobs:
             -H "${BOT_USERNAME}:${MODULE_VERSION}-${CHANNEL}" \
             -R "https://${GH_TOOLS_REPO_URL}/kyma/module-manifests/" \
             --title "Promote Warden ${MODULE_VERSION} to ${CHANNEL} channel" \
-            --body "${WARDEN_SKR_OVERRIDES_REPO_URL}/actions/runs/${{github.run_id}}"
+            --body "https://github.com/kyma-project/warden/actions/${{github.run_id}}"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix link in the new version submission worflow
- promote warden (mandatory module) to redular. Fast channel doesnt make sense in case of mandatory modules

