### PR TITLE
Skip allowed prefixes before parsing

### DIFF
--- a/internal/validate/image.go
+++ b/internal/validate/image.go
@@ -64,6 +64,12 @@ func NewImageValidator(sc *ServiceConfig, notaryClientFactory RepoFactory) Image
 func (s *notaryService) Validate(ctx context.Context, image string, imagePullCredentials map[string]cliType.AuthConfig) error {
 	logger := helpers.LoggerFromCtx(ctx).With("image", image)
 	ctx = helpers.LoggerToContext(ctx, logger)
+
+	if allowed := s.isImageAllowed(image); allowed {
+		logger.Info("image validation skipped, because it's allowed")
+		return nil
+	}
+
 	split := strings.Split(image, tagDelim)
 
 	if len(split) != 2 {
@@ -72,11 +78,6 @@ func (s *notaryService) Validate(ctx context.Context, image string, imagePullCre
 
 	imgRepo := split[0]
 	imgTag := split[1]
-
-	if allowed := s.isImageAllowed(imgRepo); allowed {
-		logger.Info("image validation skipped, because it's allowed")
-		return nil
-	}
 
 	expectedShaBytes, err := s.loggedGetNotaryImageDigestHash(ctx, imgRepo, imgTag)
 	if err != nil {

--- a/internal/validate/image_test.go
+++ b/internal/validate/image_test.go
@@ -250,6 +250,20 @@ func Test_Validate_ImageWhichIsNotInNotaryButIsInAllowedList_ShouldPass(t *testi
 				"some-registry/allowed-image-3",
 			},
 		},
+		{
+			name:      "image name has no colon delimiters but is allowed anyway",
+			imageName: "nginx",
+			allowedRegistries: []string{
+				"nginx",
+			},
+		},
+		{
+			name:      "image name has two colon delimiters but is allowed anyway",
+			imageName: "public.ecr.aws/dynatrace/dynatrace-operator:v1.3.2@sha256:f8ecdcd87d7d84b87e645074084dd7f57dd62c76e120bb21e5abde158755be56",
+			allowedRegistries: []string{
+				"public.ecr.aws/dynatrace/dynatrace-operator",
+			},
+		},
 	}
 	f := &mocks.RepoFactory{}
 	f.On("NewRepoClient", mock.Anything, mock.Anything).Return(nil, errors.New("Should be called"))


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- skip allowed registry prefixes before image parsing

**Related issue(s)**
#161 