### PR TITLE
Fix scripts using the `sec-scanner-config` file

### DIFF
--- a/.github/scripts/upgrade-sec-scanners-config.sh
+++ b/.github/scripts/upgrade-sec-scanners-config.sh
@@ -2,6 +2,6 @@
 
 IMG_VERSION=${IMG_VERSION?"Define IMG_VERSION env"}
 
-yq -i ".protecode[0] = \"europe-docker.pkg.dev/kyma-project/prod/warden/operator:${IMG_VERSION}\"" sec-scanners-config.yaml
-yq -i ".protecode[1] = \"europe-docker.pkg.dev/kyma-project/prod/warden/admission:${IMG_VERSION}\"" sec-scanners-config.yaml
+yq -i ".bdba[0] = \"europe-docker.pkg.dev/kyma-project/prod/warden/operator:${IMG_VERSION}\"" sec-scanners-config.yaml
+yq -i ".bdba[1] = \"europe-docker.pkg.dev/kyma-project/prod/warden/admission:${IMG_VERSION}\"" sec-scanners-config.yaml
 yq -i "del(.rc-tag)" sec-scanners-config.yaml


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.

If the pull request requires a decision, follow the [decision-making process](https://github.com/kyma-project/community/blob/main/governance.md) and replace the PR template with the [decision record template](https://github.com/kyma-project/community/blob/main/.github/ISSUE_TEMPLATE/decision-record.md).
-->

**Description**

Changes proposed in this pull request:

- fix all repo scripts working on the `sec-scannr-config` to use  the `bdba` instead of the `protecode` field

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/keda-manager/issues/617