### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/_build.yaml
+++ b/.github/workflows/_build.yaml
@@ -42,7 +42,6 @@ jobs:
       name: warden/admission
       dockerfile: docker/admission/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
-      build-engine: buildx
 
   build-warden-operator:
     needs: compute-tags
@@ -51,4 +50,3 @@ jobs:
       name: warden/operator
       dockerfile: docker/operator/Dockerfile
       tags: ${{ needs.compute-tags.outputs.tags }}
-      build-engine: buildx


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.